### PR TITLE
Added verify_ssl option to Pastebin methods

### DIFF
--- a/pbwrap/asyncpbwrap.py
+++ b/pbwrap/asyncpbwrap.py
@@ -7,7 +7,7 @@ try:
     import aiohttp
 
     class AsyncPaste:
-        """Defines a Paste from Pastebin paste contains the following fields:
+        """Defines a Paste from Pastebin paste which contains the following fields:
         key,
         date,
         title,
@@ -20,8 +20,9 @@ try:
         hits.
         """
 
-        def __init__(self, paste_dict):
+        def __init__(self, paste_dict, verify_ssl=True):
             self.key = None
+            self.verify_ssl = verify_ssl
             for k, v in paste_dict.items():
                 setattr(self, k, v)
 
@@ -34,7 +35,7 @@ try:
                 :rtype: string, None
             """
             if self.key is not None:
-                r = await aiohttp.get("https://pastebin.com/raw/" + self.key)
+                r = await aiohttp.get("https://pastebin.com/raw/" + self.key, **self.general_params())
                 return await r.text
             return None
 
@@ -46,15 +47,26 @@ try:
             if self.key is not None:
                 parameter = {"i": self.key}
                 r = await aiohttp.get(
-                    "https://scrape.pastebin.com/api_scrape_item.php", params=parameter
+                    "https://scrape.pastebin.com/api_scrape_item.php", params=parameter,
+                    **self.general_params()
                 )
 
                 return await r.text
             return None
 
+        def general_params(self):
+            """Returns parameters that should be included in every request
+
+                :returns: The options to be passed to aiohttp.*
+                :rtype: dictionary
+            """
+            return {
+                "verify_ssl": self.verify_ssl
+            }
+
     class AsyncPastebin(Pastebin):
         """Async version of Pastebin class.
-        
+
         Represents your communication with the Pastebin API through its functions
         you can use every API endpoint avalaible.
 
@@ -62,16 +74,19 @@ try:
         Functions for manipulating your pastes through the API require an api_user_key.
         """
 
-        def __init__(self, dev_key=None):
+        def __init__(self, dev_key=None, verify_ssl=True):
             """Instantiate a Pastebin Object
 
             :param api_dev_key: Your API Pastebin key
             :type api_dev_key: string
+
+            :param verify_ssl: If False, skips ssl certificate verification. Default: True
+            :type verify_ssl: bool
             """
-            super().__init__(api_dev_key=dev_key)
+            super().__init__(api_dev_key=dev_key, verify_ssl=verify_ssl)
 
         @staticmethod
-        async def get_raw_paste(paste_id):
+        async def get_raw_paste(paste_id, verify_ssl=True):
             """Return raw string of given paste_id.
 
             get_raw_paste(pasted_id)
@@ -79,25 +94,31 @@ try:
             :type paste_id: string
             :param paste_id: The ID key of the paste
 
+            :param verify_ssl: If `False`, does not verify ssl certificate. Default: True
+            :type verify_ssl: bool
+
             :returns: the text of the paste
             :rtype: string
             """
-            r = await aiohttp.get("https://pastebin.com/raw/" + paste_id)
+            r = await aiohttp.get("https://pastebin.com/raw/" + paste_id, verify_ssl=verify_ssl)
             return await r.text
 
         @staticmethod
-        async def get_archive():
+        async def get_archive(verify_ssl=True):
             """Return archive paste link list.Archive contains 25 most recent pastes.
+
+            :param verify_ssl: If `False`, does not verify ssl certificate. Default: True
+            :type verify_ssl: bool
 
             :returns: a list of url strings
             :rtype: list
             """
-            r = await aiohttp.get("https://pastebin.com/archive")
+            r = await aiohttp.get("https://pastebin.com/archive", verify_ssl=verify_ssl)
 
             return formatter.archive_url_format(await r.text)
 
         @staticmethod
-        async def get_recent_pastes(limit=50, lang=None):
+        async def get_recent_pastes(limit=50, lang=None, verify_ssl=True):
             """get_recent_pastes(limit=50, lang=None)
 
                 Return a list containing dictionaries of paste.
@@ -108,17 +129,21 @@ try:
                 :param lang: return only pastes from certain language defaults to None
                 :type lang: string
 
+                :param verify_ssl: If `False`, does not verify ssl certificate. Default: True
+                :type verify_ssl: bool
+
                 :returns: list of Paste objects.
                 :rtype: list(Paste)
             """
             parameters = {"limit": limit, "lang": lang}
 
             r = await aiohttp.get(
-                "https://scrape.pastebin.com/api_scraping.php", params=parameters
+                "https://scrape.pastebin.com/api_scraping.php", params=parameters,
+                verify_ssl=verify_ssl
             )
             paste_list = list()
             for paste in await r.json():
-                paste_list.append(AsyncPaste(paste))
+                paste_list.append(AsyncPaste(paste, verify_ssl=verify_ssl))
             return paste_list
 
 except ImportError:


### PR DESCRIPTION
As per #9, sometimes self-signed certificates in firewalls between the client and pastebin fail to verify, rendering the library unusable :cry: .

---
This PR adds an `ssl_verify` option to:

Instances of `Pastebin` objects: This is set in the `Pastebin.__init__` method. All calls to `requests.*` will also set the `verify` argument.

Static methods of the `Pastebin` class: In this case, the `verify_ssl` argument must be passed into each call that should use it. Another solution I could think of was something along the lines of:

```python
Pastebin.verify_ssl = False
Pastebin.get_recent_pastes()
```

However, since skipping SSL certificate verification should be a very-well thought out process, I think explicitly setting it in each call is best

The same work has been done in the `AsyncPastebin` and `AsyncPaste` classes.